### PR TITLE
Precomputed distances

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
+![Conda Version](https://img.shields.io/conda/vn/bioconda/distle)
+![Static Badge](https://img.shields.io/badge/install%20with-docker-important.svg?style=flat&logo=docker&link=https%3A%2F%2Fquay.io%2Frepository%2Fbiocontainers%2Fdistle)
+
+
+
 Build with 
 ```cargo build -r```
 
 Run with 
-```./release/distle --args```
+```./target/release/distle --args```
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ Run with
 
 
 ```
-
-Usage: distle [OPTIONS] <INPUT> <OUTPUT> [PRECOMPUTED_DISTANCES]
+Usage: distle [OPTIONS] <INPUT> <OUTPUT>
 
 Arguments:
   <INPUT>
@@ -16,13 +15,10 @@ Arguments:
   <OUTPUT>
           The output file or '-' for stdout
 
-  [PRECOMPUTED_DISTANCES]
-          A tabular file with precomputed distances that don't have to be calculated again.
-
 Options:
   -i, --input-format <INPUT_FORMAT>
           The format of the input file
-
+          
           [default: fasta]
 
           Possible values:
@@ -33,26 +29,29 @@ Options:
 
   -o, --output-format <OUTPUT_FORMAT>
           The format of the output file
-
+          
           [default: tabular]
 
           Possible values:
           - tabular: Output the distances in a tabular long format
           - phylip:  Output the distances in a Phylip format
 
+      --precomputed-distances <PRECOMPUTED_DISTANCES>
+          A file with precomputed distances that don't have to be calculated again. The file should be in tabular long format and have the separator as specified by the output-sep flag
+
       --input-sep <INPUT_SEP>
           The separator character for the input file. Relevant for tabular input files
-
+          
           [default: "\t"]
 
       --output-sep <OUTPUT_SEP>
           The separator character for the output file
-
+          
           [default: "\t"]
 
   -m, --output-mode <OUTPUT_MODE>
           The output mode
-
+          
           [default: lower-triangle]
 
           Possible values:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Build with
 ```cargo build -r```
 
 Run with 
-```./target/release/distle --args```
+```./target/release/distle --help```
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Run with
 
 
 ```
-Usage: distle [OPTIONS] <INPUT> <OUTPUT>
+
+Usage: distle [OPTIONS] <INPUT> <OUTPUT> [PRECOMPUTED_DISTANCES]
 
 Arguments:
   <INPUT>
@@ -15,10 +16,13 @@ Arguments:
   <OUTPUT>
           The output file or '-' for stdout
 
+  [PRECOMPUTED_DISTANCES]
+          A tabular file with precomputed distances that don't have to be calculated again.
+
 Options:
   -i, --input-format <INPUT_FORMAT>
           The format of the input file
-          
+
           [default: fasta]
 
           Possible values:
@@ -29,7 +33,7 @@ Options:
 
   -o, --output-format <OUTPUT_FORMAT>
           The format of the output file
-          
+
           [default: tabular]
 
           Possible values:
@@ -38,17 +42,17 @@ Options:
 
       --input-sep <INPUT_SEP>
           The separator character for the input file. Relevant for tabular input files
-          
+
           [default: "\t"]
 
       --output-sep <OUTPUT_SEP>
           The separator character for the output file
-          
+
           [default: "\t"]
 
   -m, --output-mode <OUTPUT_MODE>
           The output mode
-          
+
           [default: lower-triangle]
 
           Possible values:

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,8 @@ struct Cli {
     #[arg(value_enum, short = 'o', long, default_value = "tabular")]
     output_format: OutputFormat,
 
-    /// A file with precomputed distances that don't have to be calculated again. The file should be in the same format as the output file.
+    /// A file with precomputed distances that don't have to be calculated again. The file should be in tabular long format and have the separator as specified by the output-sep flag.
+    #[arg(long)]
     precomputed_distances: Option<String>,
 
     /// The separator character for the input file. Relevant for tabular input files.

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ use env_logger::Env;
 use log::{debug, info};
 use rayon::ThreadPoolBuilder;
 
-
 mod processing;
 mod types;
 
@@ -50,9 +49,9 @@ struct Cli {
     #[arg(short = 'd', long, default_value = None)]
     maxdist: Option<usize>,
 
-    /// Number of threads to use.
-    #[arg(short = 't', long, default_value_t = 1)]
-    threads: usize,
+    /// Number of threads to use. If not set, all available threads will be used.
+    #[arg(short = 't', long, default_value = None)]
+    threads: Option<usize>,
 
     /// Skip the header line of the input file. Relevant for tabular input files.
     #[arg(short = 's', long)]
@@ -86,7 +85,18 @@ fn main() -> Result<(), Box<dyn Error>> {
     debug!("Cli options: {:?}", opts);
 
     // Set threads
-    ThreadPoolBuilder::new().num_threads(opts.threads).build_global().unwrap();
+    match opts.threads {
+        Some(threads) => {
+            info!("Using {} threads", threads);
+            ThreadPoolBuilder::new()
+                .num_threads(threads)
+                .build_global()
+                .unwrap();
+        }
+        None => {
+            info!("Using all available threads");
+        }
+    }
 
     let start = Instant::now();
     let mut data_map = match opts.input_format {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ use std::time::Instant;
 use clap::Parser;
 use env_logger::Env;
 use log::{debug, info};
+use rayon::ThreadPoolBuilder;
+
 
 mod processing;
 mod types;
@@ -48,6 +50,10 @@ struct Cli {
     #[arg(short = 'd', long, default_value = None)]
     maxdist: Option<usize>,
 
+    /// Number of threads to use.
+    #[arg(short = 't', long, default_value_t = 1)]
+    threads: usize,
+
     /// Skip the header line of the input file. Relevant for tabular input files.
     #[arg(short = 's', long)]
     skip_header: bool,
@@ -78,6 +84,9 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // print command line arguments
     debug!("Cli options: {:?}", opts);
+
+    // Set threads
+    ThreadPoolBuilder::new().num_threads(opts.threads).build_global().unwrap();
 
     let start = Instant::now();
     let mut data_map = match opts.input_format {

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,16 +116,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     debug!("Reading time: {:?}", start.elapsed());
     let start = Instant::now();
 
-    // Remove columns that are all the same
-    // let n_removed = remove_identical_columns(&mut data_map);
-
-    // debug!(
-    //     "Removed {:?} columns that are all the same: {:?}",
-    //     n_removed,
-    //     start.elapsed()
-    // );
-    // let start = Instant::now();
-
     info!("Computing distances and writing to file: {}", &opts.output);
 
     let precomputed_distances =

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -123,36 +123,6 @@ pub fn read_and_parse_tabular_distances<'a, R: BufRead>(
     Ok(distances)
 }
 
-// pub fn remove_identical_columns<X>(data_map: &mut Vec<(X, Vec<SupportedType>)>) -> usize {
-//     let (longest_vec_index, longest_len) = data_map
-//         .iter()
-//         .enumerate()
-//         .map(|(i, (_, row))| (i, row.len()))
-//         .max_by_key(|&(_, len)| len)
-//         .unwrap_or((0, 0));
-
-//     let to_remove: HashSet<_> = (0..longest_len)
-//         .rev()
-//         .filter(|&i| {
-//             let longest = data_map[longest_vec_index].1.get(i);
-//             data_map.iter().all(|(_, row)| match (longest, row.get(i)) {
-//                 (Some(f), Some(r)) => SupportedType::eq_whithout_exeptions(f, r),
-//                 _ => false,
-//             })
-//         })
-//         .collect();
-
-//     for row in data_map {
-//         let mut index = 0;
-//         row.1.retain(|_| {
-//             let keep = !to_remove.contains(&index);
-//             index += 1;
-//             keep
-//         });
-//     }
-//     to_remove.len()
-// }
-
 pub fn compute_distances<'a>(
     data_map: &'a InputMatrix,
     maxdist: Option<usize>,
@@ -377,39 +347,4 @@ mod tests {
         assert_eq!(compute_distance_eq(&row1, &row3, None), 1);
         assert_eq!(compute_distance_eq(&row2, &row3, None), 6);
     }
-
-    // #[test]
-    // fn test_remove_identical_columns() {
-    //     let a = SupportedType::NucleotideAll(NucleotideAll::from_str("A").unwrap());
-    //     let c = SupportedType::NucleotideAll(NucleotideAll::from_str("C").unwrap());
-    //     let g = SupportedType::NucleotideAll(NucleotideAll::from_str("G").unwrap());
-    //     let t = SupportedType::NucleotideAll(NucleotideAll::from_str("T").unwrap());
-    //     let n = SupportedType::NucleotideAll(NucleotideAll::from_str("n").unwrap());
-    //     let d = SupportedType::NucleotideAll(NucleotideAll::from_str("-").unwrap());
-
-    //     let mut data_map = vec![
-    //         (String::from("id1"), vec![a, c, g, t, n, d]),
-    //         (String::from("id2"), vec![a, n, d, d, n, n]),
-    //         (String::from("id3"), vec![a, c, g, t, n, d]),
-    //     ];
-    //     let data_map_original = data_map.clone();
-    //     let expected_number_removed = 2;
-    //     let number_removed = remove_identical_columns(&mut data_map);
-
-    //     let expected_data_map = vec![
-    //         (String::from("id1"), vec![c, g, t, d]),
-    //         (String::from("id2"), vec![n, d, d, n]),
-    //         (String::from("id3"), vec![c, g, t, d]),
-    //     ];
-
-    //     assert_eq!(number_removed, expected_number_removed);
-    //     assert_eq!(data_map, expected_data_map);
-
-    //     // test that the distances are also the same
-    //     let distances_original: Vec<_> =
-    //         compute_distances(&data_map_original, None, OutputMode::Full, None).collect();
-    //     let distances: Vec<_> = compute_distances(&data_map, None, OutputMode::Full, None).collect();
-
-    //     assert_eq!(distances_original, distances);
-    // }
 }

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -206,11 +206,18 @@ fn calculate_distance(
 }
 
 fn compute_distance_eq<T: PartialEq>(row1: &[T], row2: &[T], maxdist: Option<usize>) -> usize {
-    row1.iter()
-        .zip(row2.iter())
-        .filter(|(x, y)| x != y)
-        .take(maxdist.unwrap_or(usize::MAX))
-        .count()
+    let maxdist = maxdist.unwrap_or(usize::MAX);
+    let mut count = 0;
+
+    for (x, y) in row1.iter().zip(row2.iter()) {
+        if x != y {
+            count += 1;
+            if count >= maxdist {
+                break;
+            }
+        }
+    }
+    count
 }
 
 pub fn write_distances_to_file<'a, W: Write>(

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,5 @@
 use clap::ValueEnum;
+use std::fmt::Debug;
 use std::str::FromStr;
 
 #[derive(Debug, PartialEq, Clone, Copy, ValueEnum)]
@@ -13,61 +14,33 @@ pub enum InputFormat {
     FastaAll,
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum SupportedType {
-    ChewBBACAinteger(ChewBBACAinteger),
-    SHA1Hash(SHA1Hash),
-    Nucleotide(Nucleotide),
-    NucleotideAll(NucleotideAll),
+pub type InputMatrix = Vec<(String, SupportedTypeVec)>;
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum SupportedTypeVec {
+    Nucleotide(Vec<Nucleotide>),
+    NucleotideAll(Vec<NucleotideAll>),
+    Cgmlst(Vec<ChewBBACAinteger>),
+    SHA1Hash(Vec<SHA1Hash>),
 }
 
-impl SupportedType {
-    pub fn from_str(
-        s: &str,
-        input_format: InputFormat,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        match input_format {
-            InputFormat::Cgmlst => Ok(SupportedType::ChewBBACAinteger(ChewBBACAinteger::from_str(
-                s,
-            )?)),
-            InputFormat::CgmlstHash => Ok(SupportedType::SHA1Hash(SHA1Hash::from_str(s)?)),
-            InputFormat::Fasta => Ok(SupportedType::Nucleotide(Nucleotide::from_str(s)?)),
-            InputFormat::FastaAll => Ok(SupportedType::NucleotideAll(NucleotideAll::from_str(s)?)),
-        }
-    }
+// #[derive(Debug, PartialEq, Clone, Copy)]
+// pub enum SupportedType<T> {
+//     Value(T),
+// }
 
-    pub fn from_u8(u: u8, input_format: InputFormat) -> Result<Self, Box<dyn std::error::Error>> {
-        match input_format {
-            InputFormat::Fasta => Ok(SupportedType::Nucleotide(Nucleotide::from(u))),
-            InputFormat::FastaAll => Ok(SupportedType::NucleotideAll(NucleotideAll::from(u))),
-            x => Err(format!("Type not supported: {:?}", x).into()),
-        }
-    }
-
-    /// Compare two SupportedType without exceptions that should be the same (e.g. 0 for chewbbaca and N for fasta)
-    /// This is important for the remove_identical_columns function
-    pub fn eq_whithout_exeptions(&self, other: &Self) -> bool {
-        match (self, other) {
-            (
-                SupportedType::ChewBBACAinteger(ChewBBACAinteger(x)),
-                SupportedType::ChewBBACAinteger(ChewBBACAinteger(y)),
-            ) => x == y,
-            (SupportedType::SHA1Hash(SHA1Hash(x)), SupportedType::SHA1Hash(SHA1Hash(y))) => x == y,
-            (
-                SupportedType::Nucleotide(Nucleotide(x)),
-                SupportedType::Nucleotide(Nucleotide(y)),
-            ) => x == y,
-            (
-                SupportedType::NucleotideAll(NucleotideAll(x)),
-                SupportedType::NucleotideAll(NucleotideAll(y)),
-            ) => x == y,
-            _ => panic!(
-                "Types do not match while comparing: {:?} and {:?}",
-                self, other
-            ),
-        }
-    }
-}
+// impl<T> SupportedType<T>
+// where
+//     T: FromStr + std::fmt::Debug,
+// {
+//     pub fn from_str(s: &str) -> Result<Self, Box<dyn std::error::Error>>
+//     where
+//         <T as FromStr>::Err: 'static + std::error::Error,
+//     {
+//         let value = T::from_str(s)?;
+//         Ok(SupportedType::Value(value))
+//     }
+// }
 
 #[derive(Debug, Clone, Copy)]
 pub struct ChewBBACAinteger(u16);

--- a/src/types.rs
+++ b/src/types.rs
@@ -97,38 +97,40 @@ impl std::str::FromStr for Nucleotide {
         match s {
             "A" | "a" => Ok(Nucleotide(1)),
             "C" | "c" => Ok(Nucleotide(2)),
-            "G" | "g" => Ok(Nucleotide(3)),
-            "T" | "t" => Ok(Nucleotide(4)),
-            _ => Ok(Nucleotide(0)),
+            "G" | "g" => Ok(Nucleotide(4)),
+            "T" | "t" => Ok(Nucleotide(8)),
+            _ => Ok(Nucleotide(15)),
         }
     }
 }
 
 impl PartialEq for Nucleotide {
     fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0 || self.0 == 0 || other.0 == 0
+        // this implementation is specific to the values of the Nucleotide enum
+        (self.0 & other.0) != 0
     }
 }
 
 impl From<u8> for Nucleotide {
     fn from(value: u8) -> Self {
         // Static lookup table for nucleotide values
-        static LUT: [u8; 256] = {
-            let mut lut = [0; 256];
-            lut[b'a' as usize] = b'a';
-            lut[b'c' as usize] = b'c';
-            lut[b'g' as usize] = b'g';
-            lut[b't' as usize] = b't';
-            lut[b'A' as usize] = b'a';
-            lut[b'C' as usize] = b'c';
-            lut[b'G' as usize] = b'g';
-            lut[b'T' as usize] = b't';
+        static LUT: [Nucleotide; 256] = {
+            let mut lut = [Nucleotide(15); 256];
+            lut[b'a' as usize] = Nucleotide(1);
+            lut[b'c' as usize] = Nucleotide(2);
+            lut[b'g' as usize] = Nucleotide(3);
+            lut[b't' as usize] = Nucleotide(4);
+            lut[b'A' as usize] = Nucleotide(1);
+            lut[b'C' as usize] = Nucleotide(2);
+            lut[b'G' as usize] = Nucleotide(3);
+            lut[b'T' as usize] = Nucleotide(4);
             lut
         };
 
-        Nucleotide(LUT[value as usize])
+        LUT[value as usize]
     }
 }
+
 #[derive(Debug, Clone, Copy)]
 pub struct NucleotideAll(u8);
 
@@ -139,7 +141,7 @@ impl std::str::FromStr for NucleotideAll {
         // get first char from str and put it in
         s.chars()
             .next()
-            .map(|c| Self(c as u8))
+            .map(|c| Self(c.to_ascii_lowercase() as u8))
             .ok_or("NucleotideAll::from_str: could not parse first char from string")
     }
 }
@@ -190,46 +192,39 @@ mod tests {
     fn test_nucleotide() {
         let x = Nucleotide::from_str("A").unwrap();
         assert_eq!(x, Nucleotide(1));
+        assert_ne!(x, Nucleotide::from(b'C'));
         let x = Nucleotide::from_str("C").unwrap();
         assert_eq!(x, Nucleotide(2));
         let x = Nucleotide::from_str("G").unwrap();
-        assert_eq!(x, Nucleotide(3));
-        let x = Nucleotide::from_str("T").unwrap();
         assert_eq!(x, Nucleotide(4));
+        let x = Nucleotide::from_str("T").unwrap();
+        assert_eq!(x, Nucleotide(8));
         let x = Nucleotide::from_str("a").unwrap();
         assert_eq!(x, Nucleotide(1));
         let x = Nucleotide::from_str("c").unwrap();
         assert_eq!(x, Nucleotide(2));
         let x = Nucleotide::from_str("g").unwrap();
-        assert_eq!(x, Nucleotide(3));
-        let x = Nucleotide::from_str("t").unwrap();
         assert_eq!(x, Nucleotide(4));
+        let x = Nucleotide::from_str("t").unwrap();
+        assert_eq!(x, Nucleotide(8));
         let x = Nucleotide::from_str("X").unwrap();
-        assert_eq!(x, Nucleotide(0));
-        assert_eq!(x, Nucleotide::from(1));
-        assert_eq!(x, Nucleotide::from(2));
-        assert_eq!(x, Nucleotide::from(3));
-        assert_eq!(x, Nucleotide::from(4));
+        assert_eq!(x, Nucleotide(15));
+        assert_eq!(x, Nucleotide::from(b'a'));
+        assert_eq!(x, Nucleotide::from(b'c'));
+        assert_eq!(x, Nucleotide::from(b'g'));
+        assert_eq!(x, Nucleotide::from(b't'));
     }
 
     #[test]
     fn test_nucleotide_all() {
         let x = NucleotideAll::from_str("A").unwrap();
-        assert_eq!(x, NucleotideAll(65));
+        assert_eq!(x, NucleotideAll::from(b'a'));
         let x = NucleotideAll::from_str("C").unwrap();
-        assert_eq!(x, NucleotideAll(67));
+        assert_eq!(x, NucleotideAll::from(b'c'));
         let x = NucleotideAll::from_str("G").unwrap();
-        assert_eq!(x, NucleotideAll(71));
+        assert_eq!(x, NucleotideAll::from(b'g'));
         let x = NucleotideAll::from_str("T").unwrap();
-        assert_eq!(x, NucleotideAll(84));
-        let x = NucleotideAll::from_str("a").unwrap();
-        assert_eq!(x, NucleotideAll(97));
-        let x = NucleotideAll::from_str("c").unwrap();
-        assert_eq!(x, NucleotideAll(99));
-        let x = NucleotideAll::from_str("g").unwrap();
-        assert_eq!(x, NucleotideAll(103));
-        let x = NucleotideAll::from_str("t").unwrap();
-        assert_eq!(x, NucleotideAll(116));
+        assert_eq!(x, NucleotideAll::from(b't'));
         let x = NucleotideAll::from_str("X").unwrap();
         assert_ne!(x, NucleotideAll::from_str("a").unwrap());
         assert_ne!(x, NucleotideAll::from_str("c").unwrap());

--- a/src/types.rs
+++ b/src/types.rs
@@ -23,24 +23,6 @@ pub enum SupportedTypeVec {
     SHA1Hash(Vec<SHA1Hash>),
 }
 
-// #[derive(Debug, PartialEq, Clone, Copy)]
-// pub enum SupportedType<T> {
-//     Value(T),
-// }
-
-// impl<T> SupportedType<T>
-// where
-//     T: FromStr + std::fmt::Debug,
-// {
-//     pub fn from_str(s: &str) -> Result<Self, Box<dyn std::error::Error>>
-//     where
-//         <T as FromStr>::Err: 'static + std::error::Error,
-//     {
-//         let value = T::from_str(s)?;
-//         Ok(SupportedType::Value(value))
-//     }
-// }
-
 #[derive(Debug, Clone, Copy)]
 pub struct ChewBBACAinteger(u16);
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,5 @@
 use clap::ValueEnum;
 use std::fmt::Debug;
-use std::str::FromStr;
 
 #[derive(Debug, PartialEq, Clone, Copy, ValueEnum)]
 pub enum InputFormat {
@@ -113,11 +112,23 @@ impl PartialEq for Nucleotide {
 
 impl From<u8> for Nucleotide {
     fn from(value: u8) -> Self {
-        let c = value as char;
-        Self::from_str(&c.to_string()).unwrap()
+        // Static lookup table for nucleotide values
+        static LUT: [u8; 256] = {
+            let mut lut = [0; 256];
+            lut[b'a' as usize] = b'a';
+            lut[b'c' as usize] = b'c';
+            lut[b'g' as usize] = b'g';
+            lut[b't' as usize] = b't';
+            lut[b'A' as usize] = b'a';
+            lut[b'C' as usize] = b'c';
+            lut[b'G' as usize] = b'g';
+            lut[b'T' as usize] = b't';
+            lut
+        };
+
+        Nucleotide(LUT[value as usize])
     }
 }
-
 #[derive(Debug, Clone, Copy)]
 pub struct NucleotideAll(u8);
 
@@ -136,8 +147,7 @@ impl std::str::FromStr for NucleotideAll {
 // implement construction from u8
 impl From<u8> for NucleotideAll {
     fn from(value: u8) -> Self {
-        let c = value as char;
-        Self::from_str(&c.to_string()).unwrap()
+        Self(value.to_ascii_lowercase())
     }
 }
 
@@ -150,6 +160,7 @@ impl PartialEq for NucleotideAll {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::str::FromStr;
 
     #[test]
     fn test_chewbbaca_integer() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -118,12 +118,12 @@ impl From<u8> for Nucleotide {
             let mut lut = [Nucleotide(15); 256];
             lut[b'a' as usize] = Nucleotide(1);
             lut[b'c' as usize] = Nucleotide(2);
-            lut[b'g' as usize] = Nucleotide(3);
-            lut[b't' as usize] = Nucleotide(4);
+            lut[b'g' as usize] = Nucleotide(4);
+            lut[b't' as usize] = Nucleotide(8);
             lut[b'A' as usize] = Nucleotide(1);
             lut[b'C' as usize] = Nucleotide(2);
-            lut[b'G' as usize] = Nucleotide(3);
-            lut[b'T' as usize] = Nucleotide(4);
+            lut[b'G' as usize] = Nucleotide(4);
+            lut[b'T' as usize] = Nucleotide(8);
             lut
         };
 

--- a/tests/test_output_formats.rs
+++ b/tests/test_output_formats.rs
@@ -19,7 +19,7 @@ pub fn test_output_long() {
 
     let mut data_map = read_and_parse_fasta(input, input_format).unwrap();
     remove_identical_columns(&mut data_map);
-    let distances = compute_distances(&data_map, maxdist, output_mode);
+    let distances = compute_distances(&data_map, maxdist, output_mode,None);
     write_distances_to_file(
         distances,
         &mut output,
@@ -48,7 +48,7 @@ pub fn test_output_long_all() {
 
     let mut data_map = read_and_parse_fasta(input, input_format).unwrap();
     remove_identical_columns(&mut data_map);
-    let distances = compute_distances(&data_map, maxdist, output_mode);
+    let distances = compute_distances(&data_map, maxdist, output_mode,None);
     write_distances_to_file(
         distances,
         &mut output,
@@ -77,7 +77,7 @@ pub fn test_output_phylip() {
 
     let mut data_map = read_and_parse_fasta(input, input_format).unwrap();
     remove_identical_columns(&mut data_map);
-    let distances = compute_distances(&data_map, maxdist, output_mode);
+    let distances = compute_distances(&data_map, maxdist, output_mode,None);
     write_distances_to_file(
         distances,
         &mut output,
@@ -106,7 +106,7 @@ pub fn test_output_phylip_full() {
 
     let mut data_map = read_and_parse_fasta(input, input_format).unwrap();
     remove_identical_columns(&mut data_map);
-    let distances = compute_distances(&data_map, maxdist, output_mode);
+    let distances = compute_distances(&data_map, maxdist, output_mode,None);
     write_distances_to_file(
         distances,
         &mut output,
@@ -136,7 +136,7 @@ pub fn test_input_cgmlst_hash() {
 
     let mut data_map = read_and_parse_tabular(input, input_format, input_sep, false).unwrap();
     remove_identical_columns(&mut data_map);
-    let distances = compute_distances(&data_map, maxdist, output_mode);
+    let distances = compute_distances(&data_map, maxdist, output_mode,None);
     write_distances_to_file(
         distances,
         &mut output,
@@ -166,7 +166,7 @@ pub fn test_input_cgmlst_hash_full() {
 
     let mut data_map = read_and_parse_tabular(input, input_format, input_sep, false).unwrap();
     remove_identical_columns(&mut data_map);
-    let distances = compute_distances(&data_map, maxdist, output_mode);
+    let distances = compute_distances(&data_map, maxdist, output_mode,None);
     write_distances_to_file(
         distances,
         &mut output,
@@ -196,11 +196,11 @@ pub fn test_remove_identical() {
     // assert_eq!(data_map, data_map_with_removed_columns);
 
     let dist_original: Vec<_> =
-        compute_distances(&data_map, None, OutputMode::LowerTriangle).collect();
+        compute_distances(&data_map, None, OutputMode::LowerTriangle,None).collect();
     let dist_removed: Vec<_> = compute_distances(
         &data_map_with_removed_columns,
         None,
-        OutputMode::LowerTriangle,
+        OutputMode::LowerTriangle,None
     )
     .collect();
 

--- a/tests/test_output_formats.rs
+++ b/tests/test_output_formats.rs
@@ -2,8 +2,8 @@ use std::fs::File;
 use std::io::{BufReader, Cursor, Read, Seek, SeekFrom};
 
 use distle::processing::{
-    compute_distances, read_and_parse_fasta, read_and_parse_tabular, remove_identical_columns,
-    write_distances_to_file, OutputFormat, OutputMode,
+    compute_distances, read_and_parse_fasta, read_and_parse_tabular, write_distances_to_file,
+    OutputFormat, OutputMode,
 };
 use distle::types::InputFormat;
 
@@ -17,9 +17,9 @@ pub fn test_output_long() {
     let output_mode = OutputMode::LowerTriangle;
     let maxdist = None;
 
-    let mut data_map = read_and_parse_fasta(input, input_format).unwrap();
-    remove_identical_columns(&mut data_map);
-    let distances = compute_distances(&data_map, maxdist, output_mode,None);
+    let data_map = read_and_parse_fasta(input, input_format).unwrap();
+    // remove_identical_columns(&mut data_map);
+    let distances = compute_distances(&data_map, maxdist, output_mode, None);
     write_distances_to_file(
         distances,
         &mut output,
@@ -46,9 +46,9 @@ pub fn test_output_long_all() {
     let output_mode = OutputMode::Full;
     let maxdist = None;
 
-    let mut data_map = read_and_parse_fasta(input, input_format).unwrap();
-    remove_identical_columns(&mut data_map);
-    let distances = compute_distances(&data_map, maxdist, output_mode,None);
+    let data_map = read_and_parse_fasta(input, input_format).unwrap();
+    // remove_identical_columns(&mut data_map);
+    let distances = compute_distances(&data_map, maxdist, output_mode, None);
     write_distances_to_file(
         distances,
         &mut output,
@@ -75,9 +75,9 @@ pub fn test_output_phylip() {
     let output_mode = OutputMode::LowerTriangle;
     let maxdist = None;
 
-    let mut data_map = read_and_parse_fasta(input, input_format).unwrap();
-    remove_identical_columns(&mut data_map);
-    let distances = compute_distances(&data_map, maxdist, output_mode,None);
+    let data_map = read_and_parse_fasta(input, input_format).unwrap();
+    // remove_identical_columns(&mut data_map);
+    let distances = compute_distances(&data_map, maxdist, output_mode, None);
     write_distances_to_file(
         distances,
         &mut output,
@@ -104,9 +104,9 @@ pub fn test_output_phylip_full() {
     let output_mode = OutputMode::Full;
     let maxdist = None;
 
-    let mut data_map = read_and_parse_fasta(input, input_format).unwrap();
-    remove_identical_columns(&mut data_map);
-    let distances = compute_distances(&data_map, maxdist, output_mode,None);
+    let data_map = read_and_parse_fasta(input, input_format).unwrap();
+    // remove_identical_columns(&mut data_map);
+    let distances = compute_distances(&data_map, maxdist, output_mode, None);
     write_distances_to_file(
         distances,
         &mut output,
@@ -134,9 +134,9 @@ pub fn test_input_cgmlst_hash() {
     let output_mode = OutputMode::LowerTriangle;
     let maxdist = None;
 
-    let mut data_map = read_and_parse_tabular(input, input_format, input_sep, false).unwrap();
-    remove_identical_columns(&mut data_map);
-    let distances = compute_distances(&data_map, maxdist, output_mode,None);
+    let data_map = read_and_parse_tabular(input, input_format, input_sep, false).unwrap();
+    // remove_identical_columns(&mut data_map);
+    let distances = compute_distances(&data_map, maxdist, output_mode, None);
     write_distances_to_file(
         distances,
         &mut output,
@@ -164,9 +164,9 @@ pub fn test_input_cgmlst_hash_full() {
     let output_mode = OutputMode::Full;
     let maxdist = None;
 
-    let mut data_map = read_and_parse_tabular(input, input_format, input_sep, false).unwrap();
-    remove_identical_columns(&mut data_map);
-    let distances = compute_distances(&data_map, maxdist, output_mode,None);
+    let data_map = read_and_parse_tabular(input, input_format, input_sep, false).unwrap();
+    // remove_identical_columns(&mut data_map);
+    let distances = compute_distances(&data_map, maxdist, output_mode, None);
     write_distances_to_file(
         distances,
         &mut output,
@@ -190,17 +190,18 @@ pub fn test_input_cgmlst_hash_full() {
 pub fn test_remove_identical() {
     let input = BufReader::new(File::open("tests/data/test_remove_identical.fasta").unwrap());
     let data_map = read_and_parse_fasta(input, InputFormat::Fasta).unwrap();
-    let mut data_map_with_removed_columns = data_map.clone();
-    let _n_removed = remove_identical_columns(&mut data_map_with_removed_columns);
+    let data_map_with_removed_columns = data_map.clone();
+    // let _n_removed = remove_identical_columns(&mut data_map_with_removed_columns);
 
     // assert_eq!(data_map, data_map_with_removed_columns);
 
     let dist_original: Vec<_> =
-        compute_distances(&data_map, None, OutputMode::LowerTriangle,None).collect();
+        compute_distances(&data_map, None, OutputMode::LowerTriangle, None).collect();
     let dist_removed: Vec<_> = compute_distances(
         &data_map_with_removed_columns,
         None,
-        OutputMode::LowerTriangle,None
+        OutputMode::LowerTriangle,
+        None,
     )
     .collect();
 


### PR DESCRIPTION
This PR enables users to use a previously generated distance file to reduce the number of computations to do. It is important that this file has the same input as the current file (no id's or sequences are changed), and was generated with the same option flags (e.g. --maxdist).

The memory footprint and reading time of fasta files is also dramatically reduced.

The user can specify the number of threads used with the -t or --threads flag. By default it will use as many threads as are available.